### PR TITLE
Added Monochrome Launcher Icon

### DIFF
--- a/app/src/main/res/mipmap-anydpi-v26/ic_launcher_bt.xml
+++ b/app/src/main/res/mipmap-anydpi-v26/ic_launcher_bt.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_bt_background"/>
     <foreground android:drawable="@drawable/ic_launcher_bt_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_bt_foreground"/>
 </adaptive-icon>


### PR DESCRIPTION
- Added A monochrome Launcher icon for devices that support it (TargetSDK <= 33):

#### Square, Yellow Theme, Light Mode

![image](https://github.com/kvj/hass_Bluetooth_Proxy_Companion/assets/57289288/a16b9601-f436-4857-becf-9e596a201740)

#### Round, Blue Theme, Dark Mode

![image](https://github.com/kvj/hass_Bluetooth_Proxy_Companion/assets/57289288/06ee36bc-a7f5-4183-962f-f25c66b50f39)
